### PR TITLE
Fix/method action attributes

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -34,6 +34,7 @@ is request(GET '/chained', 'Accept' => 'text/html')->content, 'text_html';
 is request(GET '/chained', 'Accept' => 'application/json')->content, 'json';
 
 is request(GET '/withmethods', 'Accept' => 'text/plain')->content, 'text_plain';
-isnt request(POST '/withmethods', 'Accept' => 'text/plain')->content, 'text_plain';
+is request(GET '/withmethods', 'Accept' => 'application/json')->code, 500;
+is request(POST '/withmethods', 'Accept' => 'text/plain')->code, 500;
 
 done_testing;

--- a/t/basic.t
+++ b/t/basic.t
@@ -3,7 +3,7 @@ use warnings FATAL =>'all';
 
 use FindBin;
 use Test::More;
-use HTTP::Request::Common qw/GET/;
+use HTTP::Request::Common qw/GET POST/;
 
 use lib "$FindBin::Bin/lib";
 use Catalyst::Test 'TestApp';
@@ -32,5 +32,8 @@ is request(GET '/chained')->content, 'error_not_accepted';
 is request(GET '/chained', 'Accept' => 'text/plain')->content, 'text_plain';
 is request(GET '/chained', 'Accept' => 'text/html')->content, 'text_html';
 is request(GET '/chained', 'Accept' => 'application/json')->content, 'json';
+
+is request(GET '/withmethods', 'Accept' => 'text/plain')->content, 'text_plain';
+isnt request(POST '/withmethods', 'Accept' => 'text/plain')->content, 'text_plain';
 
 done_testing;

--- a/t/lib/TestApp/Controller/WithMethods.pm
+++ b/t/lib/TestApp/Controller/WithMethods.pm
@@ -4,7 +4,7 @@ use Moose;
 use namespace::autoclean;
 
 BEGIN {
-  extends 'Catalyst::Controller::ActionRole';
+  extends 'Catalyst::Controller';
 }
 
 __PACKAGE__->config(

--- a/t/lib/TestApp/Controller/WithMethods.pm
+++ b/t/lib/TestApp/Controller/WithMethods.pm
@@ -1,0 +1,24 @@
+package TestApp::Controller::WithMethods;
+
+use Moose;
+use namespace::autoclean;
+
+BEGIN {
+  extends 'Catalyst::Controller::ActionRole';
+}
+
+__PACKAGE__->config(
+  action_roles => ['MatchRequestAccepts'],
+);
+
+sub root : Chained('/') PathPrefix CaptureArgs(0) {}
+
+  ## Adds GET method action attribute                                     ---vvv
+  sub text_plain : Chained('root') PathPart('') Accept('text/plain') Args(0) GET {
+    my ($self, $ctx) = @_;
+    $ctx->response->body('text_plain');
+  }
+
+__PACKAGE__->meta->make_immutable;
+
+1;


### PR DESCRIPTION
This is for #3.

It seems like `extends 'Catalyst::Controller'` is the fix that was needed.

Maybe the docs need updating?

Feel free not to merge this, as it doesn't really fix anything. I am merely just providing it for proof and posterity.